### PR TITLE
Fix: Rename pushi_it to push_it everywhere

### DIFF
--- a/IMAGES_GUIDE.md
+++ b/IMAGES_GUIDE.md
@@ -7,7 +7,7 @@
 #### **1. Lokale REDAXO-Dateien:**
 ```
 /media/notification-icon.png          ← Media-Pool Datei
-/assets/addons/pushi_it/icon.png      ← AddOn-Assets
+/assets/addons/push_it/icon.png      ← AddOn-Assets
 /assets/core/logo.png                 ← Core-Assets
 ```
 
@@ -81,7 +81,7 @@ $options = [
 ### **Mix aus lokal und extern:**
 ```php
 $options = [
-    'icon' => '/assets/addons/pushi_it/icon.png',      // Lokal
+    'icon' => '/assets/addons/push_it/icon.png',      // Lokal
     'badge' => '/media/custom-badge.png',              // Media-Pool
     'image' => 'https://cdn.example.com/hero.jpg'     // Extern
 ];
@@ -113,7 +113,7 @@ $options = [
 
 1. **Fallback immer definieren:**
    ```php
-   'icon' => $customIcon ?: '/assets/addons/pushi_it/icon.png'
+   'icon' => $customIcon ?: '/assets/addons/push_it/icon.png'
    ```
 
 2. **Bilder vorab testen:**

--- a/README.md
+++ b/README.md
@@ -265,18 +265,14 @@ rex_extension::register('PUSHI_IT_AFTER_SEND', function(rex_extension_point $ep)
 MIT License - Siehe LICENSE.md
 
 ## Support
-
-- **Dokumentation**: [REDAXO AddOn Doku](https://redaxo.org/doku/master/addons)
-- **Forum**: [REDAXO Community](https://redaxo.org/forum)  
 - **Issues**: [GitHub Issues](https://github.com/FriendsOfREDAXO/push_it/issues)
 
 ## Credits
 
-- **Lead Developer**: Thomas Skerbis
+- **Lead Developer**: [Thomas Skerbis](https://github.com/skerbis)
 - **Organization**: Friends Of REDAXO
 - **Based on**: [Web Push Protocol](https://tools.ietf.org/html/rfc8030)
 - **Library**: [Minishlink/WebPush](https://github.com/Minishlink/web-push)
-
 ---
 
 **PushIt** - Moderne Web Push Notifications für REDAXO 5 🚀

--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ $service->sendNotification(
 
 ```bash
 # Subscription erstellen
-curl -X POST "https://domain.com/redaxo/index.php?rex-api-call=pushi_it_subscribe&user_type=frontend&topics=news" \
+curl -X POST "https://domain.com/redaxo/index.php?rex-api-call=push_it_subscribe&user_type=frontend&topics=news" \
   -H "Content-Type: application/json" \
   -d '{"endpoint":"...","keys":{"p256dh":"...","auth":"..."}}'
 
 # Subscription löschen  
-curl -X POST "https://domain.com/redaxo/index.php?rex-api-call=pushi_it_unsubscribe" \
+curl -X POST "https://domain.com/redaxo/index.php?rex-api-call=push_it_unsubscribe" \
   -H "Content-Type: application/json" \
   -d '{"endpoint":"..."}'
 ```
@@ -268,7 +268,7 @@ MIT License - Siehe LICENSE.md
 
 - **Dokumentation**: [REDAXO AddOn Doku](https://redaxo.org/doku/master/addons)
 - **Forum**: [REDAXO Community](https://redaxo.org/forum)  
-- **Issues**: [GitHub Issues](https://github.com/FriendsOfREDAXO/pushi_it/issues)
+- **Issues**: [GitHub Issues](https://github.com/FriendsOfREDAXO/push_it/issues)
 
 ## Credits
 

--- a/assets/backend.js
+++ b/assets/backend.js
@@ -6,9 +6,9 @@
   document.addEventListener('DOMContentLoaded', function() {
     
     // Backend-Benachrichtigungen automatisch aktivieren wenn konfiguriert
-    if (window.rex && window.rex.pushi_it_backend_enabled && window.rex.pushi_it_public_key) {
+    if (window.rex && window.rex.push_it_backend_enabled && window.rex.push_it_public_key) {
       // Public Key setzen (sowohl für PushiIt als auch PushiItPublicKey)
-      window.PushiItPublicKey = window.rex.pushi_it_public_key;
+      window.PushiItPublicKey = window.rex.push_it_public_key;
       
       // Warten bis PushiIt verfügbar ist
       waitForPushiIt().then(() => {
@@ -45,7 +45,7 @@
       const status = await window.PushiIt.getStatus();
       
       // Prüfen ob der Benutzer bereits geantwortet hat (localStorage)
-      const hasAnswered = localStorage.getItem('pushi_it_backend_asked');
+      const hasAnswered = localStorage.getItem('push_it_backend_asked');
       
       if (!status.isSubscribed && !hasAnswered) {
         // Zeige eine Info-Nachricht anstatt automatisch zu fragen
@@ -84,7 +84,7 @@
   window.activateBackendNotifications = async function() {
     try {
       await window.PushiIt.subscribe('backend', 'system,admin');
-      localStorage.setItem('pushi_it_backend_asked', 'accepted');
+      localStorage.setItem('push_it_backend_asked', 'accepted');
       showBackendMessage('Backend-Benachrichtigungen wurden aktiviert!', 'success');
     } catch (error) {
       console.error('Backend subscription error:', error);
@@ -93,7 +93,7 @@
   };
   
   window.declineBackendNotifications = function() {
-    localStorage.setItem('pushi_it_backend_asked', 'declined');
+    localStorage.setItem('push_it_backend_asked', 'declined');
     // Alert schließen
     const alert = document.querySelector('#rex-message-container .alert');
     if (alert) {
@@ -121,7 +121,7 @@
             <i class="rex-icon fa-bell-slash"></i> Deaktivieren
           </a></li>
           <li role="separator" class="dropdown-divider"></li>
-          <li><a href="index.php?page=pushi_it" class="dropdown-item">
+          <li><a href="index.php?page=push_it" class="dropdown-item">
             <i class="rex-icon fa-cog"></i> Einstellungen
           </a></li>
         </ul>
@@ -163,12 +163,12 @@
   // Test-Benachrichtigung senden (für Admin-Bereich)
   window.PushiItBackend = {
     sendTestNotification: function() {
-      fetch('/index.php?page=pushi_it&func=test_notification', {
+      fetch('/index.php?page=push_it&func=test_notification', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },
-        body: 'rex-api-call=pushi_it_test'
+        body: 'rex-api-call=push_it_test'
       }).then(response => {
         if (response.ok) {
           showBackendMessage('Test-Benachrichtigung wurde gesendet!', 'success');
@@ -183,14 +183,14 @@
     
     // Reset-Funktion um erneut nach Backend-Subscription zu fragen
     resetBackendAsk: function() {
-      localStorage.removeItem('pushi_it_backend_asked');
+      localStorage.removeItem('push_it_backend_asked');
       checkBackendSubscription();
     }
   };
   
   // Zusätzliche Funktionen für localStorage-Reset
   window.PushiItReset = function() {
-    localStorage.removeItem('pushi_it_backend_asked');
+    localStorage.removeItem('push_it_backend_asked');
     alert('Backend-Subscription Status wurde zurückgesetzt.');
     // Banner erneut anzeigen
     showBackendNotificationPrompt();

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -18,10 +18,10 @@
     }
     
     // Service Worker registrieren oder vorhandenen abrufen
-    let reg = await navigator.serviceWorker.getRegistration('/assets/addons/pushi_it/sw.js');
+    let reg = await navigator.serviceWorker.getRegistration('/assets/addons/push_it/sw.js');
     if (!reg) {
-      reg = await navigator.serviceWorker.register('/assets/addons/pushi_it/sw.js', {
-        scope: '/assets/addons/pushi_it/'
+      reg = await navigator.serviceWorker.register('/assets/addons/push_it/sw.js', {
+        scope: '/assets/addons/push_it/'
       });
     }
     
@@ -110,7 +110,7 @@
       });
       
       const params = new URLSearchParams({
-        'rex-api-call': 'pushi_it_subscribe',
+        'rex-api-call': 'push_it_subscribe',
         user_type: userType
       });
       
@@ -150,14 +150,14 @@
   
   async function unsubscribe() {
     try {
-      const reg = await navigator.serviceWorker.getRegistration('/assets/addons/pushi_it/');
+      const reg = await navigator.serviceWorker.getRegistration('/assets/addons/push_it/');
       const subscription = await reg?.pushManager.getSubscription();
       
       if (!subscription) {
         return { success: true, info: 'no_subscription' };
       }
       
-      const response = await fetch('/index.php?rex-api-call=pushi_it_unsubscribe', {
+      const response = await fetch('/index.php?rex-api-call=push_it_unsubscribe', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -185,7 +185,7 @@
   
   async function getSubscriptionStatus() {
     try {
-      const reg = await navigator.serviceWorker.getRegistration('/assets/addons/pushi_it/');
+      const reg = await navigator.serviceWorker.getRegistration('/assets/addons/push_it/');
       const subscription = await reg?.pushManager.getSubscription();
       return {
         isSubscribed: !!subscription,

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -9,8 +9,8 @@ self.addEventListener('push', event => {
   const title = data.title || 'Benachrichtigung';
   const options = {
     body: data.body || '',
-    icon: data.icon || '/assets/addons/pushi_it/icon.png',
-    badge: '/assets/addons/pushi_it/badge.png',
+    icon: data.icon || '/assets/addons/push_it/icon.png',
+    badge: '/assets/addons/push_it/badge.png',
     data: { 
       url: data.url || '/',
       timestamp: data.timestamp || Date.now()
@@ -20,12 +20,12 @@ self.addEventListener('push', event => {
       {
         action: 'open',
         title: 'Öffnen',
-        icon: '/assets/addons/pushi_it/action-open.png'
+        icon: '/assets/addons/push_it/action-open.png'
       },
       {
         action: 'dismiss',
         title: 'Schließen',
-        icon: '/assets/addons/pushi_it/action-close.png'
+        icon: '/assets/addons/push_it/action-close.png'
       }
     ]
   };

--- a/boot.php
+++ b/boot.php
@@ -1,5 +1,5 @@
 <?php
-$addon = rex_addon::get('pushi_it');
+$addon = rex_addon::get('push_it');
 
 // Composer Autoloader laden
 if (file_exists($addon->getPath('vendor/autoload.php'))) {
@@ -16,7 +16,7 @@ if (!$addon->hasConfig('admin_notifications')) $addon->setConfig('admin_notifica
 
 // Berechtigungen registrieren
 if (rex::isBackend()) {
-    rex_perm::register('pushi_it[]', 'PushIt - Grundberechtigung');
+    rex_perm::register('push_it[]', 'PushIt - Grundberechtigung');
 }
 
 // API-Funktionen registrieren
@@ -24,8 +24,8 @@ if (rex::isBackend()) {
 require_once $addon->getPath('lib/Api/Subscribe.php');
 require_once $addon->getPath('lib/Api/Unsubscribe.php');
 
-rex_api_function::register('pushi_it_subscribe', \FriendsOfREDAXO\PushIt\Api\Subscribe::class);
-rex_api_function::register('pushi_it_unsubscribe', \FriendsOfREDAXO\PushIt\Api\Unsubscribe::class);
+rex_api_function::register('push_it_subscribe', \FriendsOfREDAXO\PushIt\Api\Subscribe::class);
+rex_api_function::register('push_it_unsubscribe', \FriendsOfREDAXO\PushIt\Api\Unsubscribe::class);
 
 // Backend Assets hinzufügen wenn Backend aktiviert ist
 if (rex::isBackend() && $addon->getConfig('backend_enabled')) {
@@ -36,8 +36,8 @@ if (rex::isBackend() && $addon->getConfig('backend_enabled')) {
     // Public Key für Backend verfügbar machen
     $publicKey = $addon->getConfig('publicKey');
     if ($publicKey) {
-        rex_view::setJsProperty('pushi_it_public_key', $publicKey);
-        rex_view::setJsProperty('pushi_it_backend_enabled', true);
+        rex_view::setJsProperty('push_it_public_key', $publicKey);
+        rex_view::setJsProperty('push_it_backend_enabled', true);
     }
 }
 
@@ -45,7 +45,7 @@ if (rex::isBackend() && $addon->getConfig('backend_enabled')) {
 if (rex::isBackend() && $addon->getConfig('admin_notifications')) {
     // System-Fehler abfangen
     rex_extension::register('SYSTEM_ERROR', function(rex_extension_point $ep) {
-        $addon = rex_addon::get('pushi_it');
+        $addon = rex_addon::get('push_it');
         $service = new \FriendsOfREDAXO\PushIt\Service\NotificationService();
         
         $title = 'System-Fehler aufgetreten';
@@ -61,7 +61,7 @@ if (rex::isBackend() && $addon->getConfig('admin_notifications')) {
         $current_packages = array_keys(rex_addon::getRegisteredAddons());
         
         if ($last_packages !== null && $current_packages !== $last_packages) {
-            $addon = rex_addon::get('pushi_it');
+            $addon = rex_addon::get('push_it');
             $service = new \FriendsOfREDAXO\PushIt\Service\NotificationService();
             
             $title = 'AddOn-Änderung erkannt';

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "friendsofredaxo/pushi_it",
+  "name": "friendsofredaxo/push_it",
   "description": "Web Push Notifications für REDAXO 5 - Frontend und Backend",
   "type": "redaxo-addon",
   "license": "MIT",
@@ -13,7 +13,7 @@
       "homepage": "https://github.com/FriendsOfREDAXO"
     }
   ],
-  "homepage": "https://github.com/FriendsOfREDAXO/pushi_it",
+  "homepage": "https://github.com/FriendsOfREDAXO/push_it",
   "require": {
     "php": "^8.0",
     "minishlink/web-push": "^9.0"

--- a/lib/Api/Subscribe.php
+++ b/lib/Api/Subscribe.php
@@ -123,14 +123,14 @@ class Subscribe extends rex_api_function
         
         // Prüfen ob Subscription bereits existiert
         $sql->setQuery(
-            "SELECT id FROM rex_pushi_it_subscriptions WHERE endpoint = ?",
+            "SELECT id FROM rex_push_it_subscriptions WHERE endpoint = ?",
             [$data['endpoint']]
         );
         
         if ($sql->getRows() > 0) {
             // Update existierende Subscription
             $sql->setQuery("
-                UPDATE rex_pushi_it_subscriptions 
+                UPDATE rex_push_it_subscriptions 
                 SET active = 1, user_type = ?, user_id = ?, topics = ?, 
                     ua = ?, lang = ?, domain = ?, updated = NOW(), last_error = NULL
                 WHERE endpoint = ?
@@ -146,7 +146,7 @@ class Subscribe extends rex_api_function
         } else {
             // Neue Subscription erstellen
             $sql->setQuery("
-                INSERT INTO rex_pushi_it_subscriptions 
+                INSERT INTO rex_push_it_subscriptions 
                 (user_id, user_type, endpoint, p256dh, auth, topics, ua, lang, domain, active, created, updated)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, NOW(), NOW())
             ", [

--- a/lib/Api/Unsubscribe.php
+++ b/lib/Api/Unsubscribe.php
@@ -102,7 +102,7 @@ class Unsubscribe extends rex_api_function
         
         // Subscription suchen
         $sql->setQuery(
-            "SELECT id FROM rex_pushi_it_subscriptions WHERE endpoint = ? AND active = 1",
+            "SELECT id FROM rex_push_it_subscriptions WHERE endpoint = ? AND active = 1",
             [$endpoint]
         );
         
@@ -115,7 +115,7 @@ class Unsubscribe extends rex_api_function
         // Subscription deaktivieren (nicht löschen für History)
         $updateSql = rex_sql::factory();
         $updateSql->setQuery(
-            "UPDATE rex_pushi_it_subscriptions 
+            "UPDATE rex_push_it_subscriptions 
              SET active = 0, updated = NOW(), last_error = NULL 
              WHERE id = ?",
             [$subscriptionId]

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -15,7 +15,7 @@ class NotificationService
     
     public function __construct()
     {
-        $this->addon = rex_addon::get('pushi_it');
+        $this->addon = rex_addon::get('push_it');
     }
     
     /**
@@ -85,7 +85,7 @@ class NotificationService
             'title' => $title,
             'body' => $body,
             'url' => $url,
-            'icon' => $options['icon'] ?? '/assets/addons/pushi_it/icon.png',
+            'icon' => $options['icon'] ?? '/assets/addons/push_it/icon.png',
             'timestamp' => time()
         ];
         
@@ -197,7 +197,7 @@ class NotificationService
             }
         }
         
-        $query = "SELECT id, endpoint, p256dh, auth FROM rex_pushi_it_subscriptions WHERE " . implode(' AND ', $where);
+        $query = "SELECT id, endpoint, p256dh, auth FROM rex_push_it_subscriptions WHERE " . implode(' AND ', $where);
         
         $sql->setQuery($query, $params);
         
@@ -221,7 +221,7 @@ class NotificationService
     private function updateSubscriptionSuccess(int $subscriptionId): void
     {
         $sql = rex_sql::factory();
-        $sql->setQuery("UPDATE rex_pushi_it_subscriptions SET last_error = NULL, updated = NOW() WHERE id = ?", [$subscriptionId]);
+        $sql->setQuery("UPDATE rex_push_it_subscriptions SET last_error = NULL, updated = NOW() WHERE id = ?", [$subscriptionId]);
     }
     
     /**
@@ -230,7 +230,7 @@ class NotificationService
     private function updateSubscriptionError(int $subscriptionId, string $error): void
     {
         $sql = rex_sql::factory();
-        $sql->setQuery("UPDATE rex_pushi_it_subscriptions SET last_error = ?, updated = NOW() WHERE id = ?", [$error, $subscriptionId]);
+        $sql->setQuery("UPDATE rex_push_it_subscriptions SET last_error = ?, updated = NOW() WHERE id = ?", [$error, $subscriptionId]);
     }
     
     /**
@@ -240,13 +240,13 @@ class NotificationService
     {
         $sql = rex_sql::factory();
         $sql->setQuery("
-            INSERT INTO rex_pushi_it_notifications (title, body, url, icon, badge, image, notification_options, topics, user_type, sent_to, delivery_errors, created_by, created)
+            INSERT INTO rex_push_it_notifications (title, body, url, icon, badge, image, notification_options, topics, user_type, sent_to, delivery_errors, created_by, created)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
         ", [
             $title,
             $body,
             $url,
-            $options['icon'] ?? '/assets/addons/pushi_it/icon.png',
+            $options['icon'] ?? '/assets/addons/push_it/icon.png',
             $options['badge'] ?? null,
             $options['image'] ?? null,
             !empty($options) ? json_encode($options) : null,

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: push_it
-version: '1.0.0'
+version: '1.0.0-alpha1'
 author: 'Thomas Skerbis, Friends Of REDAXO'
 supportpage: 'https://github.com/FriendsOfREDAXO/push_it'
 title: 'PushIt - Web Push Notifications'

--- a/package.yml
+++ b/package.yml
@@ -1,7 +1,7 @@
-package: pushi_it
+package: push_it
 version: '1.0.0'
 author: 'Thomas Skerbis, Friends Of REDAXO'
-supportpage: 'https://github.com/FriendsOfREDAXO/pushi_it'
+supportpage: 'https://github.com/FriendsOfREDAXO/push_it'
 title: 'PushIt - Web Push Notifications'
 description: 'Web Push Notifications für Frontend und Backend'
 
@@ -12,7 +12,7 @@ requires:
 
 page:
     title: 'PushIt'
-    perm: pushi_it[]
+    perm: push_it[]
     icon: rex-icon fa-bell
     subpages:
         settings:
@@ -20,22 +20,22 @@ page:
             perm: admin
         subscriptions:
             title: 'Subscriptions'
-            perm: pushi_it[]
+            perm: push_it[]
         send:
             title: 'Senden'
-            perm: pushi_it[]
+            perm: push_it[]
         history:
             title: 'Verlauf'
-            perm: pushi_it[]
+            perm: push_it[]
         backend_notify:
             title: 'Backend Benachrichtigungen'
-            perm: pushi_it[]
+            perm: push_it[]
         help:
             title: 'Hilfe'
             icon: rex-icon fa-question-circle
             subPath: README.md
             itemClass: 'pull-right'
-            perm: pushi_it[]
+            perm: push_it[]
 
 default_config:
     subject: 'mailto:info@example.com'

--- a/pages/backend_notify.php
+++ b/pages/backend_notify.php
@@ -1,7 +1,7 @@
 <?php
 use FriendsOfREDAXO\PushIt\Service\NotificationService;
 
-$addon = rex_addon::get('pushi_it');
+$addon = rex_addon::get('push_it');
 
 // Admin-Berechtigung prüfen
 $isAdmin = rex::getUser()->isAdmin();
@@ -20,7 +20,7 @@ if ($publicKey) {
 } else {
     echo rex_view::warning('
         <h4>VAPID-Schlüssel fehlen</h4>
-        <p>Bitte generieren Sie zuerst VAPID-Schlüssel in den <a href="' . rex_url::backendPage('pushi_it') . '">Einstellungen</a>, um Push-Benachrichtigungen verwenden zu können.</p>
+        <p>Bitte generieren Sie zuerst VAPID-Schlüssel in den <a href="' . rex_url::backendPage('push_it') . '">Einstellungen</a>, um Push-Benachrichtigungen verwenden zu können.</p>
     ');
 }
 
@@ -124,7 +124,7 @@ function sendQuickNotification(type, title, body) {
             send: "1"
         });
         
-        fetch("' . rex_url::backendPage('pushi_it/send') . '", {
+        fetch("' . rex_url::backendPage('push_it/send') . '", {
             method: "POST",
             headers: {
                 "Content-Type": "application/x-www-form-urlencoded",
@@ -171,7 +171,7 @@ $autoNotifyContent = '
     </li>
 </ul>
 
-<p><a href="' . rex_url::backendPage('pushi_it') . '" class="btn btn-default">
+<p><a href="' . rex_url::backendPage('push_it') . '" class="btn btn-default">
     <i class="rex-icon fa-cog"></i> Einstellungen ändern
 </a></p>';
 
@@ -190,7 +190,7 @@ $sql->setQuery("
         SUM(CASE WHEN topics LIKE '%admin%' THEN 1 ELSE 0 END) as admin_subscribers,
         SUM(CASE WHEN topics LIKE '%editorial%' THEN 1 ELSE 0 END) as editorial_subscribers,
         SUM(CASE WHEN topics LIKE '%critical%' THEN 1 ELSE 0 END) as critical_subscribers
-    FROM rex_pushi_it_subscriptions 
+    FROM rex_push_it_subscriptions 
     WHERE user_type = 'backend'
 ");
 

--- a/pages/history.php
+++ b/pages/history.php
@@ -1,5 +1,5 @@
 <?php
-$addon = rex_addon::get('pushi_it');
+$addon = rex_addon::get('push_it');
 
 // Aktionen zuerst verarbeiten
 $action = rex_request('action', 'string');
@@ -10,7 +10,7 @@ if ($action && $id > 0) {
         case 'resend':
             // Nachricht erneut senden
             $resendSql = rex_sql::factory();
-            $resendSql->setQuery("SELECT * FROM rex_pushi_it_notifications WHERE id = ?", [$id]);
+            $resendSql->setQuery("SELECT * FROM rex_push_it_notifications WHERE id = ?", [$id]);
             
             if ($resendSql->getRows() > 0) {
                 try {
@@ -45,10 +45,10 @@ if ($action && $id > 0) {
             $id = rex_get('id', 'int');
             if ($id) {
                 $sql = rex_sql::factory();
-                $sql->setQuery('DELETE FROM ' . rex::getTable('pushi_it_notifications') . ' WHERE id = ?', [$id]);
+                $sql->setQuery('DELETE FROM ' . rex::getTable('push_it_notifications') . ' WHERE id = ?', [$id]);
                 echo '<div class="alert alert-success">Benachrichtigung wurde gelöscht.</div>';
             }
-            echo '<script>window.location.href = "' . rex_url::backendPage('pushi_it/history') . '";</script>';
+            echo '<script>window.location.href = "' . rex_url::backendPage('push_it/history') . '";</script>';
         }
             break;
     }
@@ -84,13 +84,13 @@ $whereClause = !empty($whereConditions) ? 'WHERE ' . implode(' AND ', $whereCond
 
 // Gesamt-Anzahl für Pagination
 $sqlCount = rex_sql::factory();
-$sqlCount->setQuery("SELECT COUNT(*) as total FROM rex_pushi_it_notifications $whereClause", $params);
+$sqlCount->setQuery("SELECT COUNT(*) as total FROM rex_push_it_notifications $whereClause", $params);
 $totalNotifications = $sqlCount->getValue('total');
 
 // Nachrichten mit Pagination abrufen
 $sql = rex_sql::factory();
 $sql->setQuery("
-    SELECT * FROM rex_pushi_it_notifications 
+    SELECT * FROM rex_push_it_notifications 
     $whereClause
     ORDER BY created DESC 
     LIMIT $limit OFFSET $offset
@@ -121,7 +121,7 @@ $sqlStats->setQuery("
         SUM(sent_to) as total_sent,
         SUM(delivery_errors) as total_errors,
         AVG(sent_to) as avg_recipients
-    FROM rex_pushi_it_notifications
+    FROM rex_push_it_notifications
 ");
 
 $stats = [];
@@ -147,7 +147,7 @@ $stats = array_merge([
 // Filter-Formular
 $filterForm = '
 <form method="get" class="form-inline" style="margin-bottom: 20px;">
-    <input type="hidden" name="page" value="pushi_it/history">
+    <input type="hidden" name="page" value="push_it/history">
     
     <div class="form-group">
         <label for="filter_user_type">User-Typ:</label>
@@ -184,7 +184,7 @@ $filterForm = '
         <i class="rex-icon fa-search"></i> Filtern
     </button>
     
-    <a href="' . rex_url::backendPage('pushi_it/history') . '" class="btn btn-default">
+    <a href="' . rex_url::backendPage('push_it/history') . '" class="btn btn-default">
         <i class="rex-icon fa-refresh"></i> Zurücksetzen
     </a>
 </form>';
@@ -328,12 +328,12 @@ if (!empty($notifications)) {
             </td>
             <td>
                 <div class="btn-group btn-group-xs">
-                    <a href="' . rex_url::backendPage('pushi_it/history', ['action' => 'resend', 'id' => $notificationId]) . '" 
+                    <a href="' . rex_url::backendPage('push_it/history', ['action' => 'resend', 'id' => $notificationId]) . '" 
                        class="btn btn-primary" title="Erneut senden"
                        onclick="return confirm(\'Nachricht erneut senden?\')">
                         <i class="rex-icon fa-repeat"></i>
                     </a>
-                    <a href="' . rex_url::backendPage('pushi_it/history', ['action' => 'delete', 'id' => $notificationId]) . '" 
+                    <a href="' . rex_url::backendPage('push_it/history', ['action' => 'delete', 'id' => $notificationId]) . '" 
                        class="btn btn-danger" title="Löschen"
                        onclick="return confirm(\'Nachricht aus Historie löschen?\')">
                         <i class="rex-icon fa-trash"></i>
@@ -358,20 +358,20 @@ if (!empty($notifications)) {
         // Vorherige Seite
         if ($currentPage > 1) {
             $prevOffset = ($currentPage - 2) * $limit;
-            $tableContent .= '<li><a href="' . rex_url::backendPage('pushi_it/history', array_merge($_GET, ['offset' => $prevOffset])) . '">&laquo; Vorherige</a></li>';
+            $tableContent .= '<li><a href="' . rex_url::backendPage('push_it/history', array_merge($_GET, ['offset' => $prevOffset])) . '">&laquo; Vorherige</a></li>';
         }
         
         // Seitenzahlen
         for ($i = max(1, $currentPage - 2); $i <= min($totalPages, $currentPage + 2); $i++) {
             $pageOffset = ($i - 1) * $limit;
             $active = $i === $currentPage ? ' class="active"' : '';
-            $tableContent .= '<li' . $active . '><a href="' . rex_url::backendPage('pushi_it/history', array_merge($_GET, ['offset' => $pageOffset])) . '">' . $i . '</a></li>';
+            $tableContent .= '<li' . $active . '><a href="' . rex_url::backendPage('push_it/history', array_merge($_GET, ['offset' => $pageOffset])) . '">' . $i . '</a></li>';
         }
         
         // Nächste Seite
         if ($currentPage < $totalPages) {
             $nextOffset = $currentPage * $limit;
-            $tableContent .= '<li><a href="' . rex_url::backendPage('pushi_it/history', array_merge($_GET, ['offset' => $nextOffset])) . '">Nächste &raquo;</a></li>';
+            $tableContent .= '<li><a href="' . rex_url::backendPage('push_it/history', array_merge($_GET, ['offset' => $nextOffset])) . '">Nächste &raquo;</a></li>';
         }
         
         $tableContent .= '</ul></nav>';
@@ -470,7 +470,7 @@ if (!empty($notifications)) {
     <div class="alert alert-info text-center">
         <h4><i class="rex-icon fa-info-circle"></i> Keine Nachrichten gefunden</h4>
         <p>Es wurden noch keine Push-Nachrichten gesendet oder Ihre Filter-Kriterien treffen nicht zu.</p>
-        <a href="' . rex_url::backendPage('pushi_it/send') . '" class="btn btn-primary">
+        <a href="' . rex_url::backendPage('push_it/send') . '" class="btn btn-primary">
             <i class="rex-icon fa-paper-plane"></i> Erste Nachricht senden
         </a>
     </div>';

--- a/pages/index.php
+++ b/pages/index.php
@@ -1,5 +1,5 @@
 <?php
 
-$package = rex_addon::get('pushi_it');
+$package = rex_addon::get('push_it');
 echo rex_view::title('Pushi It - Web Push Notifications');
 rex_be_controller::includeCurrentPageSubPath();

--- a/pages/send.php
+++ b/pages/send.php
@@ -1,10 +1,10 @@
 <?php
 use FriendsOfREDAXO\PushIt\Service\NotificationService;
 
-$addon = rex_addon::get('pushi_it');
+$addon = rex_addon::get('push_it');
 
 // Berechtigung prüfen
-if (!rex::getUser()->hasPerm('pushi_it[]')) {
+if (!rex::getUser()->hasPerm('push_it[]')) {
     echo rex_view::error('Sie haben keine Berechtigung für diesen Bereich.');
     return;
 }
@@ -65,7 +65,7 @@ if ($doSend && $title && $body) {
 $sql = rex_sql::factory();
 $sql->setQuery("
     SELECT user_type, COUNT(*) as count 
-    FROM rex_pushi_it_subscriptions 
+    FROM rex_push_it_subscriptions 
     WHERE active = 1 
     GROUP BY user_type
 ");
@@ -109,10 +109,10 @@ if ($isAdmin) {
             
             <div class="rex-form-group form-group">
                 <label class="control-label" for="icon">Icon</label>
-                <input class="form-control" id="icon" name="icon" value="' . rex_escape($icon) . '" placeholder="/assets/addons/pushi_it/icon.png" />
+                <input class="form-control" id="icon" name="icon" value="' . rex_escape($icon) . '" placeholder="/assets/addons/push_it/icon.png" />
                 <p class="help-block"><strong>Icon-URL Formate:</strong><br>
                 • <code>/media/icon.png</code> - Lokale Datei im REDAXO Media-Ordner<br>
-                • <code>/assets/addons/pushi_it/icon.png</code> - AddOn-Assets<br>
+                • <code>/assets/addons/push_it/icon.png</code> - AddOn-Assets<br>
                 • <code>https://example.com/icon.png</code> - Externe URL (HTTPS erforderlich!)<br>
                 <em>Empfohlen: 192x192px, PNG/JPG</em></p>
             </div>
@@ -187,7 +187,7 @@ function sendTestNotification() {
             body: new URLSearchParams({
                 title: "🧪 Test-Benachrichtigung",
                 body: "Dies ist eine Test-Nachricht von Pushi It. Wenn Sie diese Nachricht sehen, funktioniert das System korrekt!",
-                url: "' . rex_url::backendPage('pushi_it') . '",
+                url: "' . rex_url::backendPage('push_it') . '",
                 user_type: "backend",
                 topics: "test,admin",
                 send: "1"
@@ -214,7 +214,7 @@ echo $fragment->parse('core/page/section.php');
 // Letzte gesendete Nachrichten anzeigen
 $sql = rex_sql::factory();
 $sql->setQuery("
-    SELECT * FROM rex_pushi_it_notifications 
+    SELECT * FROM rex_push_it_notifications 
     ORDER BY created DESC 
     LIMIT 10
 ");

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -1,5 +1,5 @@
 <?php
-$addon = rex_addon::get('pushi_it');
+$addon = rex_addon::get('push_it');
 
 $subject = rex_request('subject', 'string');
 $publicKey = rex_request('publicKey', 'string');
@@ -114,7 +114,7 @@ echo $fragment->parse('core/page/section.php');
 if ($publicKey && $frontendEnabled) {
     $frontendSnippet = '
 <!-- Pushi It Frontend Integration -->
-<script src="/assets/addons/pushi_it/frontend.js"></script>
+<script src="/assets/addons/push_it/frontend.js"></script>
 <script>
 window.PushiItPublicKey = \'' . rex_escape($publicKey, 'js') . '\';
 // Optional: Topics für Frontend-Nutzer

--- a/pages/subscriptions.php
+++ b/pages/subscriptions.php
@@ -1,5 +1,5 @@
 <?php
-$addon = rex_addon::get('pushi_it');
+$addon = rex_addon::get('push_it');
 
 // Admin-Berechtigung prüfen
 $isAdmin = rex::getUser()->isAdmin();
@@ -11,7 +11,7 @@ $sql->setQuery("
         id, user_id, user_type, endpoint, topics, ua, lang, domain, 
         created, updated, last_error, active,
         SUBSTRING(endpoint, 1, 50) as endpoint_short
-    FROM rex_pushi_it_subscriptions 
+    FROM rex_push_it_subscriptions 
     ORDER BY created DESC
 ");
 
@@ -43,7 +43,7 @@ $sqlStats->setQuery("
         COUNT(*) as total,
         SUM(CASE WHEN active = 1 THEN 1 ELSE 0 END) as active_count,
         SUM(CASE WHEN last_error IS NOT NULL THEN 1 ELSE 0 END) as error_count
-    FROM rex_pushi_it_subscriptions 
+    FROM rex_push_it_subscriptions 
     GROUP BY user_type
 ");
 
@@ -186,7 +186,7 @@ if ($action === 'delete' && $id > 0) {
         echo rex_view::error('Keine Berechtigung zum Löschen von Subscriptions.');
     } else {
         $deleteSql = rex_sql::factory();
-        $deleteSql->setQuery('DELETE FROM rex_pushi_it_subscriptions WHERE id = ?', [$id]);
+        $deleteSql->setQuery('DELETE FROM rex_push_it_subscriptions WHERE id = ?', [$id]);
         echo rex_view::success('Subscription wurde gelöscht.');
         
         // Reload um aktualisierte Daten zu zeigen

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,6 +8,6 @@ if (!$keepData) {
     $sql = rex_sql::factory();
     
     // Tabellen löschen
-    $sql->setQuery('DROP TABLE IF EXISTS `rex_pushi_it_subscriptions`');
-    $sql->setQuery('DROP TABLE IF EXISTS `rex_pushi_it_notifications`');
+    $sql->setQuery('DROP TABLE IF EXISTS `rex_push_it_subscriptions`');
+    $sql->setQuery('DROP TABLE IF EXISTS `rex_push_it_notifications`');
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,6 +1,6 @@
 <?php return array(
     'root' => array(
-        'name' => 'redaxo/pushi_it',
+        'name' => 'redaxo/push_it',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
         'reference' => '7bc8552a43850597d268eb128732e18aaa949c03',
@@ -118,7 +118,7 @@
             'aliases' => array(),
             'dev_requirement' => false,
         ),
-        'redaxo/pushi_it' => array(
+        'redaxo/push_it' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
             'reference' => '7bc8552a43850597d268eb128732e18aaa949c03',


### PR DESCRIPTION
- Package name: push_it (matching GitHub repository)
- All file references updated: pushi_it -> push_it
- Database tables renamed: rex_pushi_it_* -> rex_push_it_*
- Permissions updated: pushi_it[] -> push_it[]
- API endpoints: pushi_it_* -> push_it_*
- URL references corrected
- Added update.php for smooth migration from old naming